### PR TITLE
feat: add generate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,11 @@ Type: `String`
 Default: `manifest.json`
 
 The name of the generated manifest file in the output directory.
+
+### `options.generate`
+
+Type: `Function`
+
+Default: `undefined`
+
+A custom Function to create the manifest. The passed function should match the signature of `(entries: {[key: string]: string}) => Object`; and can return anything as long as it's serialisable by `JSON.stringify`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ interface ManifestPluginOptions {
   shortNames?: OptionValue;
   filename?: string;
   extensionless?: OptionValue;
+  generate?: (entries: {[key: string]: string}) => Object;
 }
 
 export = (options: ManifestPluginOptions = {}): Plugin => ({
@@ -94,7 +95,11 @@ export = (options: ManifestPluginOptions = {}): Plugin => ({
 
       const fullPath = path.resolve(`${outdir}/${filename}`);
 
-      const text = JSON.stringify(fromEntries(mappings), null, 2);
+      const entries = fromEntries(mappings);
+
+      const resultObj = options.generate ? options.generate(entries) : entries;
+
+      const text = JSON.stringify(resultObj, null, 2);
 
       // With the esbuild write=false option, nothing will be written to disk. Instead, the build
       // result will have an "outputFiles" property containing all the files that would have been written.

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,4 +1,4 @@
-import manifestPlugin from '../lib/index';
+import manifestPlugin from '../src/index';
 import fs from 'fs';
 import path from 'path';
 import util from 'util';
@@ -32,7 +32,7 @@ test('it returns a valid esbuild plugin interface', () => {
 });
 
 test('it works with a require call', () => {
-  const manifestPlugin = require('../lib/index');
+  const manifestPlugin = require('../src/index');
   expect(manifestPlugin()).toHaveProperty('name');
   expect(manifestPlugin()).toHaveProperty('setup');
 });
@@ -340,3 +340,9 @@ test('it should include the manifest file as part of the build result output fil
 
   expect(result.outputFiles).toContainEqual(expected);
 });
+
+test('it should modify result using generate function', async () => {
+  await require('esbuild').build(buildOptions({generate: (entries: {[key: string]: string}) => {return {files: entries}}, hash: false}));
+
+  expect(metafileContents()).toEqual({"files":{"test/input/example.js": "test/output/example.js"}});
+})


### PR DESCRIPTION
We want to be able to modify the content in manifest, this feature is similar to this: https://github.com/shellscape/webpack-manifest-plugin#generate