### PR TITLE
Fix sourcemap chunk naming conflict

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,8 +78,10 @@ export = (options: ManifestPluginOptions = {}): Plugin => ({
 
         // When code splitting is used, every chunk will be named "chunk.HASH.js". That means when there are multiple chunks,
         // every unhashed filename would be "chunk.js", which would cause a conflict in the manifest. So for chunks we'll just
-        // use the output filename including the hash as the key.
-        if (path.parse(key).name === 'chunk') {
+        // use the output filename including the hash as the key. The same goes for sourcemaps for chunks - those will also be
+        // named "chunk.HASH.js.map".
+        // By parsing the output filename twice, we get rid of the any double extension (like .js.map) if present. Non-map files are left intact.
+        if (path.parse(path.parse(key).name).name === 'chunk') { 
           key = outputFilename;
         }
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -535,3 +535,15 @@ test('it should use the hashed filename of chunks as keys when splitting is enab
   expect(metafileContents()['test/output/chunk-JYYV63CZ.js']).toEqual('test/output/chunk-JYYV63CZ.js');
   expect(metafileContents()['test/output/chunk-VDNVJE6B.js']).toEqual('test/output/chunk-VDNVJE6B.js');
 });
+
+test('it should use the hashed filename of chunks sourcemaps as keys when splitting is enabled', async () => {
+  await require('esbuild').build(buildOptions({}, {
+    entryPoints: ['test/input/splitting/index.js', 'test/input/splitting/home.js', 'test/input/splitting/about.js'],
+    splitting: true,
+    sourcemap: true,
+    format: 'esm',
+  }));
+
+  expect(metafileContents()['test/output/chunk-GLLCI6N7.js.map']).toEqual('test/output/chunk-GLLCI6N7.js.map');
+  expect(metafileContents()['test/output/chunk-4GJGTIT2.js.map']).toEqual('test/output/chunk-4GJGTIT2.js.map');
+});


### PR DESCRIPTION
## Problem
Naming conflicts in the manifest for output chunks are handled by checking if the name-part of the output file name is `chunk`. For sourcemaps, the double extension (`.js.map`) will mean that chunk names will be e.g. `chunk.js` and the comparison fails, causing duplicate keys.

Fixes the continued issues mentioned in the comments on #22 after it was closed.

## Solution
Parse the name twice (!!), which will leave normal names untouched, but remove "double extension" names like `.js.map` or `.min.css`.
It's a bit of a weird solution, but felt like the most efficient approach if wanting to avoid having to hard-code extension and create a more general solution.

Note: Chunk hashes change in the test, which I assume is on account of the sourcemapping-URL being present in the file contents. I haven't verified this though.